### PR TITLE
Add AC_PROG_CC_STDC so that gcc gets called with -std=gnu99

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,7 @@ AC_CONFIG_SRCDIR([softflowd.c])
 
 AC_CONFIG_HEADER(config.h)
 AC_PROG_CC
+AC_PROG_CC_STDC
 AC_PROG_INSTALL
 
 # Optional verbose warnings for gcc, see below


### PR DESCRIPTION
Add AC_PROG_CC_STDC so that gcc gets called with -std=gnu99 if necessary; otherwise:

ipfix.c:1053:17: error: ‘for’ loop initial declarations are only allowed in C99 mode

etc